### PR TITLE
support ament linter names with underscores

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,7 @@ on:
 
 jobs:
   test:
-    name: test_${{ matrix.linter }}
     runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
-      matrix:
-        linter: [flake8, lint_cmake]
     steps:
     - uses: actions/checkout@v1
     - run: npm ci
@@ -34,8 +29,14 @@ jobs:
         git clone --depth=1 --branch=0.8.1 \
             https://github.com/ament/ament_lint.git
     - uses: ros-tooling/setup-ros@0.0.3
-    - uses: ./ # Uses an action in the root directory
+    - name: Try default linter
+      uses: ./
       with:
-        linter: ${{ matrix.linter }}
         package-name: ament_copyright ament_lint
+        workspace-directory: ament_lint
+    - name: Try a linter with underscores in the name
+      uses: ./
+      with:
+        linter: lint_cmake
+        package-name: ament_cmake_cpplint
         workspace-directory: ament_lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,12 @@ on:
 
 jobs:
   test:
+    name: test_${{ matrix.linter }}
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        linter: [flake8, lint_cmake]
     steps:
     - uses: actions/checkout@v1
     - run: npm ci
@@ -31,5 +36,6 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.3
     - uses: ./ # Uses an action in the root directory
       with:
+        linter: ${{ matrix.linter }}
         package-name: ament_copyright ament_lint
         workspace-directory: ament_lint

--- a/dist/index.js
+++ b/dist/index.js
@@ -682,13 +682,16 @@ function run() {
             const matchersPath = path.join(__dirname, "..");
             console.log(`##[add-matcher]${path.join(matchersPath, "ament_copyright.json")}`);
             console.log(`##[add-matcher]${path.join(matchersPath, "ament_flake8.json")}`);
-            const linterTool = core.getInput("linter");
+            // linterTool is the executable name to invoke
+            // linterToolDashes is the name with only dashes used for debian package name composition
+            const linterTool = core.getInput("linter").replace("-","_");
+            const linterToolDashes = linterTool.replace("_", "-")
             const packageName = core.getInput("package-name", { required: true });
             const packageNameList = packageName.split(RegExp("\\s"));
             const rosDistribution = core.getInput("distribution");
             const rosWorkspaceDir = core.getInput("workspace-directory") || process.env.GITHUB_WORKSPACE;
             yield exec.exec("rosdep", ["update"]);
-            yield runAptGetInstall([`ros-${rosDistribution}-ament-${linterTool}`]);
+            yield runAptGetInstall([`ros-${rosDistribution}-ament-${linterToolDashes}`]);
             const options = {
                 cwd: rosWorkspaceDir
             };

--- a/src/action-ros-lint.ts
+++ b/src/action-ros-lint.ts
@@ -27,7 +27,10 @@ async function run() {
 			`##[add-matcher]${path.join(matchersPath, "ament_flake8.json")}`
 		);
 
-		const linterTool = core.getInput("linter");
+		// linterTool is the executable name to invoke
+		// linterToolDashes is the name with only dashes used for debian package name composition
+		const linterTool = core.getInput("linter").replace("-","_");
+		const linterToolDashes = linterTool.replace("_", "-")
 		const packageName = core.getInput("package-name", { required: true });
 		const packageNameList = packageName.split(RegExp("\\s"));
 		const rosDistribution = core.getInput("distribution");
@@ -36,7 +39,7 @@ async function run() {
 
 		await exec.exec("rosdep", ["update"]);
 
-		await runAptGetInstall([`ros-${rosDistribution}-ament-${linterTool}`]);
+		await runAptGetInstall([`ros-${rosDistribution}-ament-${linterToolDashes}`]);
 
 		const options = {
 			cwd: rosWorkspaceDir


### PR DESCRIPTION
This allows to use this action to run e.g. the `lint_cmake` linter


[Tested it in another repo](https://github.com/mikaelarguedas/sros2/runs/528938401?check_suite_focus=true) but not sure how to cover this in the test suite of this repo

Fixes https://github.com/ros-tooling/action-ros-lint/issues/31