### PR TITLE
Run apt-get update before trying to install linter packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   test_setup_ros:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:bionic
+      image: ubuntu:focal
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         node-version: '12.x'
     - run: .github/workflows/build-and-test.sh
-    - uses: ros-tooling/setup-ros@0.0.26
+    - uses: ros-tooling/setup-ros@v0.1
     - uses: actions/checkout@v2
       with:
         repository: ament/ament_lint
@@ -46,7 +46,7 @@ jobs:
   test_setup_ros_docker:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-latest
       options: -u root  # setup-node requires root access
     steps:
     - uses: actions/checkout@v2

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'ROS 2 Linter'
     required: false
   distribution:
-    default: 'eloquent'
+    default: 'rolling'
     description: 'ROS 2 Distribution to install the lint tool from'
     required: false
   package-name:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1102,6 +1102,7 @@ function run() {
             const rosDistribution = core.getInput("distribution");
             const rosWorkspaceDir = core.getInput("workspace-directory") || process.env.GITHUB_WORKSPACE;
             yield exec.exec("rosdep", ["update"]);
+            yield exec.exec("sudo", ["apt-get", "update"]);
             yield runAptGetInstall([`ros-${rosDistribution}-ament-${linterToolDashes}`]);
             const options = {
                 cwd: rosWorkspaceDir

--- a/src/action-ros-lint.ts
+++ b/src/action-ros-lint.ts
@@ -39,6 +39,7 @@ export async function run() {
 
 		await exec.exec("rosdep", ["update"]);
 
+		await exec.exec("sudo", ["apt-get", "update"]);
 		await runAptGetInstall([`ros-${rosDistribution}-ament-${linterToolDashes}`]);
 
 		const options = {


### PR DESCRIPTION
And run those tests on a more recent representative environment

This should allow users to run the build in simply the "ubuntu-DISTRO-latest" container without having to use ros-base, if desired. Modified the test to mae that scenario true