### PR TITLE
Add support for custom linter arguments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,13 @@ jobs:
         linter: lint_cmake
         package-name: ament_cmake_cpplint
         workspace-directory: ament_lint
+    - name: Try a linter with additional arguments
+      uses: ./
+      with:
+        linter: lint_cmake
+        arguments: '--filter=-linelength,+syntax'
+        package-name: ament_cmake_cpplint
+        workspace-directory: ament_lint
 
   test_setup_ros_docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,17 +36,17 @@ jobs:
       with:
         package-name: ament_copyright ament_lint
         workspace-directory: ament_lint
-    - name: Try a linter with underscores in the name
-      uses: ./
-      with:
-        linter: lint_cmake
-        package-name: ament_cmake_cpplint
-        workspace-directory: ament_lint
     - name: Try a linter with additional arguments
       uses: ./
       with:
         linter: lint_cmake
         arguments: '--filter=-linelength,+syntax'
+        package-name: ament_cmake_cpplint
+        workspace-directory: ament_lint
+    - name: Try a linter with underscores in the name
+      uses: ./
+      with:
+        linter: lint_cmake
         package-name: ament_cmake_cpplint
         workspace-directory: ament_lint
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
       uses: ./
       with:
         linter: lint_cmake
+        arguments: '--filter=-linelength'
         package-name: ament_cmake_cpplint
         workspace-directory: ament_lint
 
@@ -73,10 +74,18 @@ jobs:
       with:
         package-name: ament_copyright ament_lint
         workspace-directory: ament_lint
+    - name: Try a linter with additional arguments
+      uses: ./
+      with:
+        linter: lint_cmake
+        arguments: '--filter=-linelength,+syntax'
+        package-name: ament_cmake_cpplint
+        workspace-directory: ament_lint
     - name: Try a linter with underscores in the name
       uses: ./
       with:
         linter: lint_cmake
+        arguments: '--filter=-linelength'
         package-name: ament_cmake_cpplint
         workspace-directory: ament_lint
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
     default: 'flake8'
     description: 'ROS 2 Linter'
     required: false
+  arguments:
+    description: 'Additional arguments for linter'
+    required: false
   distribution:
     default: 'rolling'
     description: 'ROS 2 Distribution to install the lint tool from'

--- a/src/action-ros-lint.ts
+++ b/src/action-ros-lint.ts
@@ -36,6 +36,7 @@ export async function run() {
 		const rosDistribution = core.getInput("distribution");
 		const rosWorkspaceDir =
 			core.getInput("workspace-directory") || process.env.GITHUB_WORKSPACE;
+		const additionalArguments = core.getInput("arguments");
 
 		await exec.exec("rosdep", ["update"]);
 
@@ -56,7 +57,7 @@ export async function run() {
 				`source /opt/ros/${rosDistribution}/setup.sh && ` +
 					`ament_${linterTool} $(colcon list --packages-select ${packageNameList.join(
 						" "
-					)} -p)`
+					)} -p) ${additionalArguments}`
 			],
 			options
 		);


### PR DESCRIPTION
Adds an optional `arguments` input to the action which is appended to the linter command upon run.

Includes test for running with modified arguments, as well as running without arguments specified.