### PR TITLE
Set linelength to 140 for lint action.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1056,7 +1056,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -1101,6 +1101,7 @@ function run() {
             const packageNameList = packageName.split(RegExp("\\s"));
             const rosDistribution = core.getInput("distribution");
             const rosWorkspaceDir = core.getInput("workspace-directory") || process.env.GITHUB_WORKSPACE;
+            const additionalArguments = core.getInput("arguments");
             yield exec.exec("rosdep", ["update"]);
             yield exec.exec("sudo", ["apt-get", "update"]);
             yield runAptGetInstall([`ros-${rosDistribution}-ament-${linterToolDashes}`]);
@@ -1113,7 +1114,7 @@ function run() {
             yield exec.exec("bash", [
                 "-c",
                 `source /opt/ros/${rosDistribution}/setup.sh && ` +
-                    `ament_${linterTool} $(colcon list --packages-select ${packageNameList.join(" ")} -p)`
+                    `ament_${linterTool} $(colcon list --packages-select ${packageNameList.join(" ")} -p) --linelength=140 ${additionalArguments}`
             ], options);
         }
         catch (error) {

--- a/src/action-ros-lint.ts
+++ b/src/action-ros-lint.ts
@@ -57,7 +57,7 @@ export async function run() {
 				`source /opt/ros/${rosDistribution}/setup.sh && ` +
 					`ament_${linterTool} $(colcon list --packages-select ${packageNameList.join(
 						" "
-					)} -p) ${additionalArguments}`
+					)} -p) --linelength=140 ${additionalArguments}`
 			],
 			options
 		);


### PR DESCRIPTION
This resolves the discrepency between the line lenght used during the package
builds and the line length used by this action.

Workaround for this ament issue: https://github.com/ament/ament_lint/issues/301