### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -3,6 +3,18 @@ set -euxo pipefail
 
 npm install -g codecov
 
+# When running inside a Docker container, by default, we're root and all files belond to root.
+# However, calling the npm scripts (build, etc.) with 'npm run ...' runs the commands as user
+# ID=1001, which means we can't open or write to any files. Therefore, if we're in Docker, chown
+# everything under /__w (which is the workspace directory on the host: /home/runner/work) to user
+# ID=1001. See:
+# * https://github.com/ros-tooling/setup-ros/pull/521
+# * https://github.com/npm/cli/issues/4589
+docker_workdir="/__w"
+if [ -d "${docker_workdir}" ]; then
+  chown -R 1001:1001 "${docker_workdir}"
+fi
+
 npm ci
 npm run build
 npm test

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-npm install -g codecov
-
 # When running inside a Docker container, by default, we're root and all files belond to root.
 # However, calling the npm scripts (build, etc.) with 'npm run ...' runs the commands as user
 # ID=1001, which means we can't open or write to any files. Therefore, if we're in Docker, chown
@@ -18,8 +16,3 @@ fi
 npm ci
 npm run build
 npm test
-
-# Upload code coverage result to Codecov
-codecov -f ./coverage/coverage-final.json \
-    --disable=detect --commit="${GITHUB_SHA}" \
-    --branch="${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,6 @@ on:
     # Run the CI automatically every hour to look for flakyness.
     - cron:  '0 * * * *'
 
-env:
-  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
 jobs:
   test_setup_ros:
     runs-on: ubuntu-latest


### PR DESCRIPTION
First error is the same as https://github.com/ros-tooling/action-ros-ci/pull/778/commits/5f904120dcc5b0153e1c477d336c5ca754b1c130

Should fix this: https://github.com/ros-tooling/action-ros-lint/actions/runs/10337899369/job/28615293659#step:5:89

```
Error: fatal: detected dubious ownership in repository at '/__w/action-ros-lint/action-ros-lint'
```

-----

The second error is an outdated codecov. Let's just remove it.